### PR TITLE
fix: split out technical plan into two docs

### DIFF
--- a/docs/performance-api.md
+++ b/docs/performance-api.md
@@ -1,0 +1,5 @@
+# Performance API Design
+
+Status: DRAFT
+
+This doc will be a scratch pad to work out the mid level api which focuses on performance. This api will sit below the Web Compat high level api.

--- a/docs/web-compat-api.md
+++ b/docs/web-compat-api.md
@@ -1,0 +1,6 @@
+# Web Comapt API Design
+
+Status: DRAFT
+
+This doc will be a scratch pad to work out the high level api which focuses on web api compat. This includes apis based on the WHATWG `Request` and `Resonse` apis and other similar
+areas.

--- a/docs/web-compat-api.md
+++ b/docs/web-compat-api.md
@@ -4,3 +4,150 @@ Status: DRAFT
 
 This doc will be a scratch pad to work out the high level api which focuses on web api compat. This includes apis based on the WHATWG `Request` and `Resonse` apis and other similar
 areas.
+
+## Request APIs
+
+https://fetch.spec.whatwg.org/#request-class
+
+NOTE: All fields from the spec listed so we can decide if all make sense in the Node.js context, we should fill in each with that context. Additionally, because this spec is client oriented, it is not expected that the server side work in the same way. 
+
+### `new Request(RequestInit)`
+
+**`RequestInit.method`**
+
+**`RequestInit.headers`**
+
+**`RequestInit.body`**
+
+**`RequestInit.referrer`**
+
+**`RequestInit.referrerPolicy`**
+
+**`RequestInit.mode`**
+
+**`RequestInit.credentials`**
+
+**`RequestInit.cache`**
+
+**`RequestInit.redirect`**
+
+**`RequestInit.integrity`**
+
+**`RequestInit.keepalive`**
+
+**`RequestInit.signal`**
+
+**`RequestInit.duplex`**
+
+**`RequestInit.priority`**
+
+**`RequestInit.window`**
+
+---
+
+### `request.method`
+
+### `request.url`
+
+### `request.headers`
+
+### `request.destination`
+
+### `request.referrer`
+
+### `request.referrerPolicy`
+
+### `request.mode`
+
+### `request.credentials`
+
+### `request.cache`
+
+### `request.redirect`
+
+### `request.integrity`
+
+### `request.keepalive`
+
+### `request.isReloadNavigation`
+
+### `request.isHistoryNavigation`
+
+### `request.signal`
+
+### `request.duplex`
+
+### `request.clone()`
+
+
+---
+
+## APIs from popular frameworks
+
+### Header Helpers: `request.getHeader()`, `request.setHeader()`
+
+### Cookie Helpers: `request.cookies`
+
+### Cache Helpers: `request.fresh`, `request.stale`, 
+
+### Proxy/IP Helpers: `request.ip`, `request.ips`
+
+### URL Helpers: `request.protocol`, `request.hostname`, `request.path`, `request.query`
+
+### Content Negotiation: `request.contentType()`, `request.is()`, `request.accepts()`, `request.acceptsCharsets()`, `request.acceptsEncodings()`, `request.acceptsLanguages()`
+
+### Range Header Helpers: `request.range()`
+
+
+
+## Response APIs
+
+https://fetch.spec.whatwg.org/#response-class
+
+NOTE: All fields from the spec listed so we can decide if all make sense in the Node.js context, we should fill in each with that context. Additionally, because this spec is client oriented, it is not expected that the server side work in the same way. 
+
+### `new Response(BodyInit, ResponseInit)`
+
+### `responseInit.status`
+
+### `responseInit.statusText`
+
+### `responseInit.headers`
+
+--- 
+
+### `response.error()`
+
+### `response.redirect(url, status)`
+
+### `response.json(data, ResponseInit)`
+
+### `response.type`
+
+### `response.url`
+
+### `response.redirected`
+
+### `response.status`
+
+### `response.ok`
+
+### `response.statusText`
+
+### `response.headers`
+
+### `response.clone()`
+
+---
+
+## APIs from popular frameworks
+
+### Status Helpers: `response.status()`, `response.code()`, `response.sendStatus()`
+
+### Header Helpers: `response.setHeader()`, `response.getHeader()`
+
+### Cookie Helpers: `response.cookie()`, `response.clearCookie()`
+
+### Redirect Helpers: `response.redirect()`, `response.location()`
+
+### Body Helpers: `response.json()`, `response.jsonp()`, `response.attachment()`, `response.download()`, `response.format()`, `response.send()`, `response.sendFile()`


### PR DESCRIPTION
cc @ronag @qard  Based on the discussion today I just wanted to put something into motion. I figured this would be an alright way to structure it. Also I hope this can address @mcollina's comment in #2 which is that the copied over comments from previous conversations did not make it clear that we have a goal of enabling more performance oriented apis.

Specifically the idea is multiple layers where each builds upon the level below it:

1. High level Web Compat API
2. High level Performance Critical API
3. Core http APIs
4. Low level network apis

I specifically did  not create docs for 3 and 4 but I am open to creating those docs as a shell for future work but personally I think it is most important to start with the higher level 1/2 designs. Ideally by merging this shell quickly we can start proposing additions independently.